### PR TITLE
Start notification support

### DIFF
--- a/lib/integrity/builder.rb
+++ b/lib/integrity/builder.rb
@@ -21,6 +21,7 @@ module Integrity
       @logger.info "Started building #{repo.uri} at #{commit}"
       checkout.run
       @build.update(:started_at => Time.now, :commit => checkout.metadata)
+      @build.project.enabled_notifiers.each { |n| n.notify_of_build_start(@build) }
     end
 
     def run

--- a/lib/integrity/notifier.rb
+++ b/lib/integrity/notifier.rb
@@ -26,5 +26,9 @@ module Integrity
     def klass
       self.class.available[name]
     end
+
+    def notify_of_build_start(build)
+      klass.notify_of_build_start(build, config) if klass
+    end
   end
 end


### PR DESCRIPTION
I updated the start notifications changeset off of HEAD and pushed to "start_notifications" branch on my fork (closes issue #41).  There are a few details in the full commit message (see: http://github.com/tomkersten/integrity/commit/69d882554b35e931b352d821d9ad3cd1311d5c1a vs. the single-line message you are shown by default on commits).

Let me know what you think.
