### PR TITLE
fix cleanup task: get build directory from config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,11 +53,11 @@ end
 
 begin
   namespace :resque do
+    require "init"
     require "resque/tasks"
 
     desc "Start a Resque worker for Integrity"
     task :work do
-      require "init"
       ENV["QUEUE"] = "integrity"
       Rake::Task["resque:resque:work"].invoke
     end


### PR DESCRIPTION
Hi guys

I noticed that cleanup task is not working due to mistype. Could you accept this patch?

Thanks
