### PR TITLE
resque rake task: init.rb should be required before resque/tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,11 +53,11 @@ end
 
 begin
   namespace :resque do
+    require "init"
     require "resque/tasks"
 
     desc "Start a Resque worker for Integrity"
     task :work do
-      require "init"
       ENV["QUEUE"] = "integrity"
       Rake::Task["resque:resque:work"].invoke
     end


### PR DESCRIPTION
Hi guys

This patch fixes resque task.

I cannot find how to send pull request with only one commit (maybe I need to make another fork), so look at this commit only bd34ea228dea40eff0c4ff12e91fe84557e82c87
