### PR TITLE
Deal with incompatible psych YAML parser

### DIFF
--- a/lib/integrity/checkout.rb
+++ b/lib/integrity/checkout.rb
@@ -24,7 +24,9 @@ module Integrity
       result = run_in_dir!("git show -s --pretty=format:\"#{format}\" #{sha1}")
       dump   = YAML.load(result.output)
 
-      dump.update("committed_at" => Time.parse(dump["committed_at"]))
+      unless dump["committed_at"].kind_of? Time
+        dump.update("committed_at" => Time.parse(dump["committed_at"]))
+      end
     end
 
     def sha1


### PR DESCRIPTION
The new psych YAML parser is not 100% compatible with the older
parser.  If any gem requests psych, it alters all future YAML
parsing. In my environment bundler-1.0.18 was the culprit.

checkout.rb expects `committed_at` to be a string, but psych
automatically parses it into a `Time`.  This patch should make it work
with either parser.
