### PR TITLE
Run git submodule init separately from git submodule update, for the benefit of old versions of git

### DIFF
--- a/lib/integrity/checkout.rb
+++ b/lib/integrity/checkout.rb
@@ -14,7 +14,9 @@ module Integrity
         c.run! "git fetch origin"
         c.run! "git checkout origin/#{@repo.branch}"
         c.run! "git reset --hard #{sha1}"
-        c.run! "git submodule update --init"
+        # run init separately for compatibility with old versions of git
+        c.run! "git submodule init"
+        c.run! "git submodule update"
       end
     end
 


### PR DESCRIPTION
I'm running integrity on centos which ships a pretty old version of git, and get the following error when trying to build a project:

<pre>
DEBUG -- : (cd repos/19 && git submodule update --init 2>&1)
ERROR -- : "Usage: /usr/bin/git-submodule [--quiet] [--cached] [add <repo> [-b branch]|status|init|update|summary [-n|--summary-limit <n>] [<commit>]] [--] [<path>...]"
</pre>


<pre>
% git --version
git version 1.5.5.6
</pre>


`git submodule update --init` appears to be equivalent to `git submodule init && git submodule update`, which is the change I've made in this pull request.
