### PR TITLE
Bugfixes for notifications on master

### DIFF
--- a/lib/integrity/notifier/base.rb
+++ b/lib/integrity/notifier/base.rb
@@ -67,10 +67,10 @@ EOM
         end
 
         def self.log_and_notify_with_timeout(log_message, &block)
-          Integrity.log log_message
+          Integrity.logger.info(log_message)
           Timeout.timeout(8) { yield }
         rescue Timeout::Error
-          Integrity.log "#{to_s} notifier timed out"
+          Integrity.logger.info("#{to_s} notifier timed out")
           false
         end
     end


### PR DESCRIPTION
It looks like some code had been removed from master which still had references to it, preventing notifications from working.

I included commit hashes for responsible commits into respective commit log messages.

Is nobody running master with notifications?
