### PR TITLE
Do not lazy load author as it is used in project display

### DIFF
--- a/lib/integrity/author.rb
+++ b/lib/integrity/author.rb
@@ -17,7 +17,8 @@ module Integrity
 
   class Author < DataMapper::Property::String
     length 65535
-    lazy   true
+    # author is used in project display, do not lazy load it
+    lazy   false
 
     def self.unknown
       AuthorStruct.parse("author not loaded")


### PR DESCRIPTION
We have been running integrity for a while and have accumulated a few hundred builds in some projects. When displaying these projects, integrity performs 638 queries, most of which are of the following form:

<pre>
Query       SELECT `id`, `author` FROM `integrity_commits` WHERE `id` = 3778 ORDER BY `id`
</pre>


Attached change cuts the number of queries down to 14 by requesting eager load of author column.
