### PR TITLE
Added an option to limit how many builds are shown in projects.

### DIFF
--- a/doc/integrity.txt
+++ b/doc/integrity.txt
@@ -41,12 +41,13 @@ Integrity is configured via the `init.rb` file using Ruby.
 [source, ruby]
 ----
 Integrity.configure do |c|
-  c.database  = "sqlite3:integrity.db"
-  c.directory = "builds"
-  c.base_url  = "http://ci.example.org"
-  c.log       = "integrity.log"
-  c.builder   = :threaded, 5
-  c.build_all = true
+  c.database                    = "sqlite3:integrity.db"
+  c.directory                   = "builds"
+  c.base_url                    = "http://ci.example.org"
+  c.log                         = "integrity.log"
+  c.builder                     = :threaded, 5
+  c.build_all                   = true
+  c.project_default_build_count = 10
 end
 ----
 
@@ -71,6 +72,8 @@ auto_branch!:: Say the project _Integrity_ is tracking the master branch, and
 I push my _build-duration_ topic branch to GitHub, Integrity will create and
 build a new project named _Integrity (build-duration)_ using the same build
 command and notifiers.
+project_default_build_count:: How many builds to initially show on project
+pages. nil, which is the default, means show all builds.
 HTTP authentication:: If both the `user` and `pass` settings are set then only
 the logged-in users can administer the projects and see the private ones.
 [source, ruby]

--- a/init.rb
+++ b/init.rb
@@ -25,11 +25,12 @@ require "integrity"
 # require "integrity/notifier/shell"
 
 Integrity.configure do |c|
-  c.database     = "sqlite3:integrity.db"
-  c.directory    = "builds"
-  c.base_url     = "http://ci.example.org"
-  c.log          = "integrity.log"
-  c.github_token = "SECRET"
-  c.build_all    = true
-  c.builder      = :threaded, 5
+  c.database                    = "sqlite3:integrity.db"
+  c.directory                   = "builds"
+  c.base_url                    = "http://ci.example.org"
+  c.log                         = "integrity.log"
+  c.github_token                = "SECRET"
+  c.build_all                   = true
+  c.builder                     = :threaded, 5
+  c.project_default_build_count = 10
 end

--- a/lib/integrity/app.rb
+++ b/lib/integrity/app.rb
@@ -74,6 +74,25 @@ module Integrity
     get "/:project" do
       login_required unless current_project.public?
 
+      if limit = Integrity.config.project_default_build_count
+        @builds = current_project.sorted_builds.all(:limit => limit + 1)
+        if @builds.length == limit
+          @showing_all_builds = true
+        end
+      else
+        @builds = current_project.sorted_builds
+        @showing_all_builds = true
+      end
+
+      show :project, :title => ["projects", current_project.name]
+    end
+
+    get "/:project/all" do
+      login_required unless current_project.public?
+
+      @builds = current_project.sorted_builds
+      @showing_all_builds = true
+
       show :project, :title => ["projects", current_project.name]
     end
 

--- a/lib/integrity/configuration.rb
+++ b/lib/integrity/configuration.rb
@@ -9,7 +9,8 @@ module Integrity
       :github_token,
       :log,
       :username,
-      :password
+      :password,
+      :project_default_build_count
 
     def build_all?
       !! @build_all

--- a/views/project.haml
+++ b/views/project.haml
@@ -22,10 +22,14 @@
   - unless @project.blank?
     %h2 Builds
     %ul#previous_builds
-      - @project.sorted_builds.each do |build|
+      - @builds.each do |build|
         %li{ :class => build.status }
           %a{ :href => build_path(build) }
             %strong.build<
               &== Build #{build.sha1_short}
             %span.attribution<
               == by #{build.author}, #{pretty_date build.committed_at}
+
+  - unless @showing_all_builds
+    %p
+      %a{ :href => project_path(@project, :all) } See all builds


### PR DESCRIPTION
When a project accumulates a large number of builds, displaying all of them takes a long time. Allow specifying a small number of builds to be displayed initially, with all builds still displayable if needed.

One of our project has 600+ builds. The time taken to display the project is 4 seconds without this patch, 0.16 seconds with the patch.
