### PR TITLE
Build limit fixes

### DIFF
--- a/lib/integrity/app.rb
+++ b/lib/integrity/app.rb
@@ -78,6 +78,9 @@ module Integrity
         @builds = current_project.sorted_builds.all(:limit => limit + 1)
         if @builds.length <= limit
           @showing_all_builds = true
+        else
+          # we fetched one build more than needed
+          @builds.pop
         end
       else
         @builds = current_project.sorted_builds


### PR DESCRIPTION
I noticed two problems with the build limit changes in #122:
1. If there are fewer builds in a project than the build limit, the "see all builds" link is going to be unnecessarily displayed due to a wrong comparison operator.
2. One extra build is fetched to determine if more builds exist than we want to display; that extra build should not be displayed.
