### PR TITLE
Report actual exceptions when requires fail

### DIFF
--- a/lib/integrity/notifier/campfire.rb
+++ b/lib/integrity/notifier/campfire.rb
@@ -1,7 +1,8 @@
 begin
   require "broach"
 rescue LoadError => e
-  abort "Install broach to use the Campfire notifier: #{e.class}: #{e.message}"
+  warn "Install broach to use the Campfire notifier: #{e.class}: #{e.message}"
+  raise
 end
 
 module Integrity

--- a/lib/integrity/notifier/email.rb
+++ b/lib/integrity/notifier/email.rb
@@ -1,7 +1,8 @@
 begin
   require "pony"
 rescue LoadError => e
-  abort "Install pony to use the Email notifier: #{e.class}: #{e.message}"
+  warn "Install pony to use the Email notifier: #{e.class}: #{e.message}"
+  raise
 end
 
 module Integrity

--- a/lib/integrity/notifier/notifo.rb
+++ b/lib/integrity/notifier/notifo.rb
@@ -1,7 +1,8 @@
 begin
   require "notifo"
 rescue LoadError => e
-  abort "Install notifo to use the Notifo notifier: #{e.class}: #{e.message}"
+  warn "Install notifo to use the Notifo notifier: #{e.class}: #{e.message}"
+  raise
 end
 
 module Integrity

--- a/test/acceptance/manual_build_test.rb
+++ b/test/acceptance/manual_build_test.rb
@@ -182,6 +182,7 @@ class ManualBuildTest < Test::Unit::AcceptanceTestCase
       assert_have_tag("h1", :content => "Built #{repo.short_head} successfully")
     rescue LoadError, NameError => e
       warn "Couldn't load DJ. Skipping test: #{e.class}: #{e.message}"
+      raise
     ensure
       # TODO
       Integrity.config.instance_variable_set(:@builder, old_builder)


### PR DESCRIPTION
Swallowing exceptions makes for some misleading problem reports. For example, when broach is installed on a system that does not use rubygems and one attempts to run tests, the result is:

<pre>
% rake test:acceptance
(in /home/test1/integrity)
/usr/local/lib/ruby/vendor_ruby/1.8/dm-core.rb:26: warning: already initialized constant Mash
DataMapper::Sweatshop::Unique - ParseTree could not be loaded, anonymous uniques will not be allowed
Loaded suite /usr/local/lib/ruby/vendor_ruby/1.8/rake/rake_test_loader
Started
EEE...Install broach to use the Campfire notifier
rake aborted!
Command failed with status (1): [/usr/local/bin/ruby -I"lib:test" "/usr/loc...]

(See full trace by running task with --trace)
</pre>


With attached patch applied:

<pre>
% rake test:acceptance                 
(in /home/test1/integrity)
/usr/local/lib/ruby/vendor_ruby/1.8/dm-core.rb:26: warning: already initialized constant Mash
DataMapper::Sweatshop::Unique - ParseTree could not be loaded, anonymous uniques will not be allowed
Loaded suite /usr/local/lib/ruby/vendor_ruby/1.8/rake/rake_test_loader
Started
EEE...Install broach to use the Campfire notifier: LoadError: no such file to load -- rubygems
rake aborted!
Command failed with status (1): [/usr/local/bin/ruby -I"lib:test" "/usr/loc...]

(See full trace by running task with --trace)
</pre>


True reason for failure is https://github.com/Manfred/broach/pull/6.
