### PR TITLE
Check that uri was given to tcp notifier

### DIFF
--- a/lib/integrity/notifier/tcp.rb
+++ b/lib/integrity/notifier/tcp.rb
@@ -16,7 +16,11 @@ module Integrity
       end
 
       def initialize(build, config={})
-        @uri = URI(config.delete("uri"))
+        uri = config.delete('uri')
+        unless uri
+          raise ArgumentError, 'uri not given in config'
+        end
+        @uri = URI(uri)
         super
       end
 


### PR DESCRIPTION
When running tests I get the following error several times:

<pre>
  1) Error:
test_Notifying_a_failed_build(TCPNotificationTest):
URI::InvalidURIError: bad URI(is not URI?): 
    /usr/local/lib/ruby/1.8/uri/common.rb:436:in `split'
    /usr/local/lib/ruby/1.8/uri/common.rb:485:in `parse'
    /usr/local/lib/ruby/1.8/uri/common.rb:608:in `URI'
    lib/integrity/notifier/tcp.rb:20:in `initialize'
    ./lib/integrity/notifier/base.rb:6:in `new'
    ./lib/integrity/notifier/base.rb:6:in `notify'
    ./lib/integrity/notifier/base.rb:71:in `log_and_notify_with_timeout'
    /usr/local/lib/ruby/1.8/timeout.rb:62:in `timeout'
    ./lib/integrity/notifier/base.rb:71:in `log_and_notify_with_timeout'
    ./lib/integrity/notifier/base.rb:6:in `notify'
    ./lib/integrity/notifier.rb:23:in `notify'
    ./lib/integrity/build.rb:37:in `notify'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/collection.rb:511:in `each'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/support/lazy_array.rb:413:in `each'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/support/lazy_array.rb:413:in `each'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/collection.rb:508:in `each'
    ./lib/integrity/build.rb:37:in `notify'
    ./lib/integrity/builder.rb:42:in `notify'
    ./lib/integrity/builder.rb:17:in `build'
    ./lib/integrity/builder.rb:4:in `build'
    ./lib/integrity/build.rb:33:in `run!'
    ./test/helper/acceptance.rb:75:in `enqueue'
    ./lib/integrity/build.rb:29:in `run'
    ./lib/integrity/project.rb:44:in `build'
    ./lib/integrity/project.rb:34:in `build_head'
    ./lib/integrity/app.rb:139:in `POST /:project/builds'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:1057:in `call'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:1057:in `compile!'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:643:in `instance_eval'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:643:in `route_eval'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:627:in `route!'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:675:in `process_route'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:672:in `catch'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:672:in `process_route'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:626:in `route!'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:625:in `each'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:625:in `route!'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:760:in `dispatch!'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:553:in `call!'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:725:in `instance_eval'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:725:in `invoke'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:725:in `catch'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:725:in `invoke'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:553:in `call!'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:538:in `call'
    /usr/local/lib/ruby/vendor_ruby/1.8/rack/methodoverride.rb:24:in `call'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:1167:in `call'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:1193:in `synchronize'
    /usr/local/lib/ruby/vendor_ruby/1.8/sinatra/base.rb:1167:in `call'
    /usr/local/lib/ruby/vendor_ruby/1.8/rack/mock_session.rb:30:in `request'
    /usr/local/lib/ruby/vendor_ruby/1.8/rack/test.rb:219:in `process_request'
    /usr/local/lib/ruby/vendor_ruby/1.8/rack/test.rb:66:in `post'
    /usr/local/lib/ruby/vendor_ruby/1.8/webrat/core/session.rb:280:in `send'
    /usr/local/lib/ruby/vendor_ruby/1.8/webrat/core/session.rb:280:in `process_request'
    /usr/local/lib/ruby/vendor_ruby/1.8/webrat/core/session.rb:119:in `request_page'
    /usr/local/lib/ruby/vendor_ruby/1.8/webrat/core/elements/form.rb:20:in `submit'
    /usr/local/lib/ruby/vendor_ruby/1.8/webrat/core/elements/field.rb:193:in `click'
    /usr/local/lib/ruby/vendor_ruby/1.8/webrat/core/scope.rb:291:in `click_button'
    /usr/local/lib/ruby/vendor_ruby/1.8/webrat/core/methods.rb:7:in `click_button'
    test/acceptance/tcp_notification_test.rb:32:in `build'
    test/acceptance/tcp_notification_test.rb:46:in `test_Notifying_a_failed_build'

</pre>


For whatever reason uri is not passed in config to the tcp notifier.

This patch adds an explicit check that uri was given, making the error message more useful:

<pre>
  1) Error:
test_Notifying_a_failed_build(TCPNotificationTest):
ArgumentError: uri not given in config
    lib/integrity/notifier/tcp.rb:21:in `initialize'
    ./lib/integrity/notifier/base.rb:6:in `new'
    ./lib/integrity/notifier/base.rb:6:in `notify'
    ./lib/integrity/notifier/base.rb:71:in `log_and_notify_with_timeout'
    /usr/local/lib/ruby/1.8/timeout.rb:62:in `timeout'
    ./lib/integrity/notifier/base.rb:71:in `log_and_notify_with_timeout'
    ./lib/integrity/notifier/base.rb:6:in `notify'
    ./lib/integrity/notifier.rb:23:in `notify'
    ./lib/integrity/build.rb:37:in `notify'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/collection.rb:511:in `each'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/support/lazy_array.rb:413:in `each'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/support/lazy_array.rb:413:in `each'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/collection.rb:508:in `each'
    ./lib/integrity/build.rb:37:in `notify'
    ./lib/integrity/builder.rb:42:in `notify'
    ./lib/integrity/builder.rb:17:in `build'
    ./lib/integrity/builder.rb:4:in `build'
    ./lib/integrity/build.rb:33:in `run!'
    ./test/helper/acceptance.rb:75:in `enqueue'
    ./lib/integrity/build.rb:29:in `run'
    ./lib/integrity/project.rb:44:in `build'
    ./lib/integrity/project.rb:34:in `build_head'
    ./lib/integrity/app.rb:139:in `POST /:project/builds'
...
</pre>
