### PR TITLE
Enclose command in braces when normalizing it.

### DIFF
--- a/lib/integrity/command_runner.rb
+++ b/lib/integrity/command_runner.rb
@@ -40,10 +40,16 @@ module Integrity
     end
 
     def normalize(cmd)
+      # bash requires lists to end with a semicolon (or a newline).
+      # see http://wiki.bash-hackers.org/syntax/ccmd/grouping_plain
+      # zsh has no such restriction.
+      unless cmd[-1] == ?;
+        cmd += ';'
+      end
       if @dir
-        "(cd #{@dir} && #{cmd} 2>&1)"
+        "cd #{@dir} && { #{cmd} } 2>&1"
       else
-        "(#{cmd} 2>&1)"
+        "{ #{cmd} } 2>&1"
       end
     end
 


### PR DESCRIPTION
I came across this code while working on other things.

Without braces && may have incorrect binding, and standard error redirection may apply to only part of the executed command.

Somehow after I made this change I started seeing the output of time. One of our projects had the following build command:

`time ci-script`

Integrity (v22) would only show the output of ci-script, not time. With this change time is shown as well.
