### PR TITLE
Do not delete config keys in notifiers.

### DIFF
--- a/lib/integrity/notifier/amqp.rb
+++ b/lib/integrity/notifier/amqp.rb
@@ -24,8 +24,8 @@ module Integrity
       end
 
       def initialize(build, config={})
-        @exchange_name = config.delete("exchange_name")
-        @queue_host = config.delete("queue_host")
+        @exchange_name = config["exchange_name"]
+        @queue_host = config["queue_host"]
         super
       end
 

--- a/lib/integrity/notifier/email.rb
+++ b/lib/integrity/notifier/email.rb
@@ -15,8 +15,8 @@ module Integrity
       end
 
       def initialize(build, config={})
-        @to     = config.delete("to")
-        @from   = config.delete("from")
+        @to     = config["to"]
+        @from   = config["from"]
         super(build, config)
         configure_mailer
       end

--- a/lib/integrity/notifier/http.rb
+++ b/lib/integrity/notifier/http.rb
@@ -16,7 +16,7 @@ module Integrity
       end
 
       def initialize(build, config={})
-        @url = URI(config.delete("url"))
+        @url = URI(config["url"])
         super
       end
 

--- a/lib/integrity/notifier/notifo.rb
+++ b/lib/integrity/notifier/notifo.rb
@@ -15,9 +15,9 @@ module Integrity
       end
 
       def initialize(build, config={})
-        @account    = config.delete("account")
-        @token      = config.delete("token")
-        @recipients = config.delete("recipients")
+        @account    = config["account"]
+        @token      = config["token"]
+        @recipients = config["recipients"]
         super(build, config)
       end
 

--- a/lib/integrity/notifier/shell.rb
+++ b/lib/integrity/notifier/shell.rb
@@ -26,8 +26,8 @@ module Integrity
       end
 
       def initialize(build, config={})
-        @success_cmd = config.delete("success_script")
-        @failed_cmd = config.delete("failed_script")
+        @success_cmd = config["success_script"]
+        @failed_cmd = config["failed_script"]
         super
       end
 

--- a/lib/integrity/notifier/tcp.rb
+++ b/lib/integrity/notifier/tcp.rb
@@ -16,7 +16,7 @@ module Integrity
       end
 
       def initialize(build, config={})
-        uri = config.delete('uri')
+        uri = config['uri']
         unless uri
           raise ArgumentError, 'uri not given in config'
         end


### PR DESCRIPTION
When config is passed in as a hash variable, deleting keys affects said varaible in the caller. If multiple notifiers are instantiated with the same config, deleting keys has the effect of subsequent notifiers receiving only parts of the configuration (if any at all) and failing to operate.

Practically speaking this created the following errors:

<pre>
  4) Error:
test_Sending_the_notification_via_SMTP(EmailNotificationTest):
ArgumentError: :to is required
    /usr/local/lib/ruby/vendor_ruby/1.8/pony.rb:125:in `mail'
    lib/integrity/notifier/email.rb:24:in `deliver!'
    ./lib/integrity/notifier/base.rb:6:in `notify'
    ./lib/integrity/notifier/base.rb:71:in `log_and_notify_with_timeout'
    /usr/local/lib/ruby/1.8/timeout.rb:62:in `timeout'
    ./lib/integrity/notifier/base.rb:71:in `log_and_notify_with_timeout'
    ./lib/integrity/notifier/base.rb:6:in `notify'
    ./lib/integrity/notifier.rb:23:in `notify'
    ./lib/integrity/build.rb:37:in `notify'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/collection.rb:511:in `each'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/support/lazy_array.rb:413:in `each'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/support/lazy_array.rb:413:in `each'
    /usr/local/lib/ruby/vendor_ruby/1.8/dm-core/collection.rb:508:in `each'
    ./lib/integrity/build.rb:37:in `notify'
    ./lib/integrity/builder.rb:42:in `notify'
    ./lib/integrity/builder.rb:17:in `build'
    ./lib/integrity/builder.rb:4:in `build'
    ./lib/integrity/build.rb:33:in `run!'
    ./test/helper/acceptance.rb:75:in `enqueue'
    ./lib/integrity/build.rb:29:in `run'
    ./lib/integrity/project.rb:44:in `build'
    ./lib/integrity/project.rb:34:in `build_head'
    ./lib/integrity/app.rb:117:in `POST /:project/builds'
...
    ./test/acceptance/email_notification_test.rb:42:in `test_Sending_the_notification_via_SMTP'
</pre>


That error also was showing in actual use.

In my estimation the breakage possibly started sometime around when "start build" notifications were added, as they iterated over all notifiers in one place: 69d882554b35e931b352d821d9ad3cd1311d5c1a
