### PR TITLE
WebMock.reset_webmock was deprecated, use WebMock.reset! as other tests already do

### DIFF
--- a/test/acceptance/shell_notification_test.rb
+++ b/test/acceptance/shell_notification_test.rb
@@ -18,7 +18,7 @@ class ShellNotificationTest < Test::Unit::AcceptanceTestCase
   end
 
   teardown do
-    WebMock.reset_webmock
+    WebMock.reset!
   end
 
   def commit(successful)


### PR DESCRIPTION
This kills two deprecation warnings.
