### PR TITLE
Dependency cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :test do
   gem "rr",              "1.0.2"
   gem "mocha",           "0.9.10"
   gem "redgreen",        "1.2.2"
-  gem "dm-sweatshop",    "~> 1.0.2", :git => "git://github.com/datamapper/dm-sweatshop.git"
+  gem "dm-sweatshop",    "~> 1.0.2"
   gem "randexp",         "~> 0.1.6"
   gem "pony",            "1.1"
   gem "notifo",          "0.1.0"


### PR DESCRIPTION
1. Deleted unused dependencies
2. Use do_sqlite3 0.10.7 on ruby 1.9 as ruby 1.9.3-preview1 is incompatible with anything less than 0.10.7.
3. Deleted git option on dm-sweatshop, it was breaking bundle install when gemfile.lock was removed.

The last change produces epic amounts of spam from dataobjects because they had the brilliant idea to deprecate how connection parameters were specified (!!) but tests now pass on 1.9.3-preview1 with patches in #136 applied.

I put all changes into one pull request to avoid conflicts.

This pull request fixes/supersedes #102, #107, #119 and #120.

This pull request does not change gemfile.lock. Its contents is different for 1.8 and 1.9 due to ruby-debug. I'm inclined to suggest deleting it entirely since its existence does not guarantee bundle install will be able to install anything anyway (for example, v22 is currently uninstallable due to randexp git reference despite gemfile.lock).
