### PR TITLE
When return value of save/update is not checked, raise exceptions on failure

### DIFF
--- a/test/acceptance/browse_builds_test.rb
+++ b/test/acceptance/browse_builds_test.rb
@@ -48,6 +48,7 @@ class BrowseBuildsTest < Test::Unit::AcceptanceTestCase
 
   scenario "Looking for details on the last build" do
     build = Build.gen(:successful, :output => "This is the build output")
+    build.commit.raise_on_save_failure = true
     build.commit.update(
       :identifier => "7fee3f0014b529e2b76d591a8085d76eab0ff923",
       :author  => "Nicolas Sanguinetti <contacto@nicolassanguinetti.info>",

--- a/test/unit/helpers_test.rb
+++ b/test/unit/helpers_test.rb
@@ -27,6 +27,8 @@ class HelpersTest < IntegrityTest
     build = Build.gen
     commit_id = build.sha1
 
+    project.raise_on_save_failure = true
+
     project.builds << build
     project.save
 

--- a/test/unit/notifier_test.rb
+++ b/test/unit/notifier_test.rb
@@ -29,6 +29,7 @@ class NotifierTest < IntegrityTest
 
     assert_no_change(project.notifiers, :count) {
       project.notifiers << Notifier.gen(:irc, :config => "foo")
+      # returns false, does not save project
       project.save
     }
   end


### PR DESCRIPTION
Related to #78. Integrity performs save/update calls in several places without checking their return values. Notably this happens when gathering a commit's metadata during build. If a commit message is too long, save fails silently and integrity fails later when it tries to update build status, due to the build's child (commit) being dirty.

The change here causes unchecked save/update calls to raise exceptions on failure, such that the problems are reported against the code actually responsible for them.

Proper handling of long commit messages is in #130.
