### PR TITLE
Allow any 1.3.x version of sqlite3-ruby to be used, newer versions of it...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem "rack",                  "1.1.0"
 group :test do
   gem "ruby-debug",      "0.10.4" if RUBY_VERSION < '1.9'
   gem "extlib",          "0.9.15"
-  gem "sqlite3-ruby",    "1.3.2"
+  gem "sqlite3-ruby",    "~> 1.3.2"
   gem "delayed_job",     "2.1.2"
   gem "activerecord",    "3.0.3"
   gem "i18n",            "0.5.0"


### PR DESCRIPTION
... reinstate support for older versions of sqlite

Tests pass with sqlite3-ruby 1.3.5 (patched with https://github.com/luislavena/sqlite3-ruby/pull/59) on both 1.8 and 1.9.
