### PR TITLE
Email Notifier: no such file to load -- active_support/inflector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ builds
 *.log
 .rvmrc
 *.tmproj
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "rack",                  "1.1.0"
 # These are dependencies for the various notifiers. Uncomment as appropriate.
 # = Email
 # gem "pony", "1.1"
+# gem 'activesupport' 
 
 # = Campfire
 # gem "broach", "0.2.1"


### PR DESCRIPTION
Must include activesupport for email notificaiton or else mail gem via pony raises exception.

This is likely a pony or mail issue, but the mail gem appears to properly prevent this from occurring...

Adding activesupport when using pony email notifier to the Gemfile resolves this issue for me.

```
no such file to load -- active_support/inflector
/var/www/integrity/shared/bundle/ruby/1.9.1/gems/mail-2.4.1/lib/mail.rb 38
```
