### PR TITLE
Delete ruby 1.9 incompatibility note.

### DIFF
--- a/doc/integrity.txt
+++ b/doc/integrity.txt
@@ -15,7 +15,7 @@ website] and http://en.wikipedia.org/wiki/Continuous_Integration[Wikipedia].
 == Installation
 Make sure your system meet these prerequisites:
 
-* Ruby >= 1.8.6 (currently doesn't work on 1.9.X)
+* Ruby >= 1.8.6
 * RubyGems >= 1.3.5
 * git >= 1.6
 


### PR DESCRIPTION
Integrity's test suite passes on 1.9.3 and it was reported
working on 1.9.2.
