### PR TITLE
Initialize ThreadedBuilder::ThreadPool's @logger before spawning workers

### DIFF
--- a/lib/integrity/threaded_builder.rb
+++ b/lib/integrity/threaded_builder.rb
@@ -86,10 +86,10 @@ module Integrity
 
       # Default pool size is 2 threads.
       def initialize(size, logger)
+        @logger  = logger
         @jobs    = Queue.new
         @njobs   = Incrementor.new
         @workers = Array.new(size) { spawn }
-        @logger  = logger
       end
 
       # Adds a job to the queue, the job can be any number of objects


### PR DESCRIPTION
This is a small change to initialize the `@logger` instance variable in ThreadedBuilder::ThreadPool before creating workers that reference it. 

If a worker thread tries to touch `@logger` before it's ready, the thread will die with a NoMethodError exception and Integrity won't spawn a replacement. I found this out when I was adding extra start/stop logging to the workers.
