### PR TITLE
Pass the Building Branch as an ENV Variable

### DIFF
--- a/lib/integrity/checkout.rb
+++ b/lib/integrity/checkout.rb
@@ -67,7 +67,7 @@ module Integrity
     end
 
     def run_in_dir(command)
-      in_dir { |r| r.run(command) }
+      in_dir { |r| r.run("INTEGRITY_BRANCH=\"#{@repo.branch}\" " + command) }
     end
 
     def run_in_dir!(command)


### PR DESCRIPTION
My build scripts utilize this as a way to trigger additional sub-builds, allowing parallel building of the same commit. That piece of infrastructure is not suited for inclusion in mainstream Integrity, and this is all we need to do it.
