### PR TITLE
Fixed dm-postgres-adapter gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "bcat",                  "0.5.2"
 
 # Uncomment if you're using pg or mysql instead of sqlite
 # gem "pg"
-# gem "dm-postgres-adapter", "1.0.2"
+# gem "dm-postgres-adapter", "~> 1.2.0"
 # If installing dependencies with rpg:
 # gem "do_postgres", "0.10.2"
 


### PR DESCRIPTION
The datamapper gem was changed to `~> 1.2.0`, but the optional commented-out dm-postgres-adapter was left at `1.0.2`, which causes errors if you uncomment it and try running bundle install. This updates the commented postgres adapter to the compatible version.
