### PR TITLE
Added about for configuring log for heroku

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -40,6 +40,7 @@ Integrity.configure do |c|
   # Heroku
   # c.directory                 = File.dirname(__FILE__) + '/tmp/builds'
   c.base_url                    = "http://ci.example.org"
+  # Heroku - Comment out c.log
   c.log                         = "integrity.log"
   c.github_token                = "SECRET"
   c.build_all                   = true


### PR DESCRIPTION
The heroku cedar stack throws an error and puts the app into "crash" status if config.log is set. Added a comment to comment the log out if using Heroku, since Heroku will pipe anything in stdout to the heroku application log.
