### PR TITLE
Added ability to git checkout via ssh identity key

### DIFF
--- a/git_ssh
+++ b/git_ssh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [[ "$1" != "run" && "$1" != "head" && "$1" != "show" ]]; then
+  exec ssh -i "$IDENTITY_FILE" -o "StrictHostKeyChecking no" "$@"
+fi
+
+export IDENTITY_FILE="`mktemp /tmp/tmp.XXXXXXXX`"
+echo "$DEPLOY_PRIVATE_KEY" > "$IDENTITY_FILE"
+echo "$DEPLOY_PUBLIC_KEY" > "$IDENTITY_FILE.pub"
+
+self="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/"$(basename $0)"
+export GIT_SSH="$self"
+
+if [ "$1" == "run" ]; then
+  git clone $2 $3
+  cd $3 && git fetch origin && git checkout origin/$4 && git reset --hard $5 && git submodule init && git submodule update
+elif [ "$1" == "head" ]; then
+  echo "$(git ls-remote --heads $2 $3)"
+elif [ "$1" == "show" ]; then
+  echo "$(cd $2 && git show -s --pretty=format:"$3" $4)"
+fi
+
+rm -f "$IDENTITY_FILE"
+rm -f "$IDENTITY_FILE.pub"
+
+exit 0


### PR DESCRIPTION
The docs state that it isn't possible to setup Integrity to use an SSH deploy key on Heroku. I didn't consider any of the workarounds to be acceptable for our situation, so I figured out a way to make this work. Taking a note from [this stackoverflow post](http://stackoverflow.com/a/3500308/366381), I created a bash wrapper for the git commands, so that they could use a private SSH deploy key.

With this pull request, you simply need to generate a new ssh key pair ([see github instructions](https://help.github.com/articles/generating-ssh-keys), but make sure not to do this in your local .ssh directory, as nether of these keys are for your local machine).

Then, add the public ssh key to your github repo's deploy keys (at github.com/myrepo/admin/keys). And add the contents of the private key to a heroku config var.

```
heroku config:add DEPLOY_PRIVATE_KEY="----contents of private key
second line of private key
make sure to use double quotes
to allow multi-line config var value
end of private key-----------"
```

Now, when Integrity detects the `ENV['DEPLOY_PRIVATE_KEY']` variable, it will use the git_ssh wrapper for the git commands.
