### PR TITLE
Fix rbenv ENV propagation issue

### DIFF
--- a/lib/integrity/command_runner.rb
+++ b/lib/integrity/command_runner.rb
@@ -53,7 +53,7 @@ module Integrity
       end
     end
 
-    BUNDLER_VARS = %w(BUNDLE_GEMFILE RUBYOPT BUNDLE_BIN_PATH)
+    SIDE_EFFECT_VARS = %w(BUNDLE_GEMFILE RUBYOPT BUNDLE_BIN_PATH RBENV_DIR)
 
     # The idea is shamelessly stolen from Bundler.
     #
@@ -77,7 +77,7 @@ module Integrity
     # gemset.
     def with_clean_env
       bundled_env = ENV.to_hash
-      BUNDLER_VARS.each{ |var| ENV.delete(var) }
+      SIDE_EFFECT_VARS.each{ |var| ENV.delete(var) }
       yield
     ensure
       ENV.replace(bundled_env.to_hash)


### PR DESCRIPTION
I'm using rbenv and I had the following issue:
my tests (using rbenv) were run with integrity's `RBENV_DIR` environnement variable.
This means ruby version specified in my project's `.rbenv-version`  were not used, the tests always runned with the global ruby version.

I fixed it by cleaning the `RBENV_DIR` variable the same way you did for the bundler variables.
