### PR TITLE
Pending build reload

### DIFF
--- a/lib/app/views/build.haml
+++ b/lib/app/views/build.haml
@@ -5,3 +5,6 @@
   %p
     %button{ :title => "Delete this build" }
       Delete this build
+- if @build.pending? || @build.building?
+  %script{ :type => 'text/javascript' }
+    setTimeout(function() { window.location.reload(); }, 5000);


### PR DESCRIPTION
This is a very crude implementation but it should work fine for builds.

Unlike builds projects transition from bulit to building, the same logic for them would have to run all the time, at which point it will reload the project page when someone is reading build output.
