### PR TITLE
Fixing DateTime to Time conversion

### DIFF
--- a/lib/integrity.rb
+++ b/lib/integrity.rb
@@ -75,37 +75,15 @@ module Integrity
     Integrity::App
   end
 
-  def self.datetime_to_time(datetime)
-    if datetime.respond_to?(:to_time)
-      # ruby 1.9 or activesupport
-      time = datetime.to_time
-      if time.is_a?(Time)
-        return time
-      end
-      
-      # in activesupport, to_time does not always return Time
-      # http://pathfindersoftware.com/2009/09/rails-datetimetotime-time-case-why-that/
-      if datetime.respond_to?(:utc)
-        # but activesupport adds a utc conversion which can then
-        # be converted to time!
-        if datetime.utc.respond_to?(:to_time)
-          time = datetime.utc.to_time
-          if time.is_a?(Time)
-            return time
-          end
-        end
-      end
+  def self.datetime_to_utc_time(datetime)
+    if datetime.offset != 0
+      # This converts to utc
+      # borrowed from activesupport DateTime#to_utc
+      datetime = datetime.new_offset(0)
     end
     
-    datetime_to_time_manually(datetime)
-  end
-  
-  # based on DateTime#to_time of activesupport but saner
-  def self.datetime_to_time_manually(datetime)
-    if datetime.offset == 0
-      ::Time.utc(datetime.year, datetime.month, datetime.day, datetime.hour, datetime.min, datetime.sec)
-    else
-      raise ArgumentError, "DateTime with a non-zero offset (#{datetime.offset}) cannot be converted to Time"
-    end
+    # This is what DateTime#to_time does some of the time.
+    # Our offset is always 0 and therefore we always produce a Time
+    ::Time.utc(datetime.year, datetime.month, datetime.day, datetime.hour, datetime.min, datetime.sec)
   end
 end

--- a/lib/integrity/build.rb
+++ b/lib/integrity/build.rb
@@ -143,13 +143,14 @@ module Integrity
     
     def human_duration
       return if pending? || building?
-      delta = Integrity.datetime_to_time(completed_at).to_i - Integrity.datetime_to_time(started_at).to_i
+      delta = Integrity.datetime_to_utc_time(completed_at).to_i - Integrity.datetime_to_utc_time(started_at).to_i
       ChronicDuration.output(delta, :format => :micro)
     end
     
     def human_time_since_start
       return if pending?
-      delta = Time.now.utc.to_i - Integrity.datetime_to_time(started_at).utc.to_i
+      # to_i returns utc timestamp
+      delta = Time.now.to_i - Integrity.datetime_to_utc_time(started_at).to_i
       ChronicDuration.output(delta, :format => :micro)
     end
 

--- a/test/unit/datetime_conversion_test.rb
+++ b/test/unit/datetime_conversion_test.rb
@@ -1,13 +1,15 @@
 require "helper"
 
 class DatetimeConversionTest < IntegrityTest
+=begin We no longer care but leave this for debugging purposes
   setup do
     assert !Object.const_defined?(:ActiveSupport), 'activesupport should not be loaded'
   end
+=end
   
   it 'converts DateTime.now to Time' do
     dt = DateTime.now
-    time = Integrity.datetime_to_time(dt)
+    time = Integrity.datetime_to_utc_time(dt)
     assert time.is_a?(Time)
   end
   
@@ -15,7 +17,7 @@ class DatetimeConversionTest < IntegrityTest
     dt = DateTime.now
     dt = dt.new_offset(0)
     assert_equal 0, dt.offset
-    time = Integrity.datetime_to_time(dt)
+    time = Integrity.datetime_to_utc_time(dt)
     assert time.is_a?(Time)
   end
   
@@ -23,7 +25,7 @@ class DatetimeConversionTest < IntegrityTest
     dt = DateTime.now
     dt = dt.new_offset(Rational(-5, 24))
     assert_equal Rational(-5, 24), dt.offset
-    time = Integrity.datetime_to_time(dt)
+    time = Integrity.datetime_to_utc_time(dt)
     assert time.is_a?(Time)
   end
 end


### PR DESCRIPTION
Convert DateTime to UTC Time.

This works because we only need deltas.
