### PR TITLE
Provide JSON Serializations of Build Statuses

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -120,6 +120,14 @@ module Integrity
       send_file File.join(File.dirname(__FILE__), 'public', 'status', current_project.status.to_s + '.png')
     end
 
+    get "/:project\.json" do
+      if current_project.public? || authorized?
+        json current_project
+      else
+        json_error 401, "Authorization Required"
+      end
+    end
+
     get "/:project" do
       login_required unless current_project.public?
 
@@ -193,18 +201,18 @@ module Integrity
 
     get "/:project/builds/:build/artifacts/:artifact" do |project, build, artifact|
       login_required unless current_project.public?
-      
+
       artifact = CGI.unescape(artifact)
-      
+
       artifact_files = current_build.artifact_files
       file = artifact_files.detect do |file|
         file[:relative_path] == artifact
       end
-      
+
       if file.nil?
         halt 404
       end
-      
+
       fs_path = current_build.build_directory.join(file[:relative_path])
       unless File.exist?(fs_path)
         halt 404
@@ -212,7 +220,7 @@ module Integrity
 
       send_file fs_path, :filename => file[:name]
     end
-    
+
     get "/:project/builds/:build" do
       login_required unless current_project.public?
 

--- a/lib/app/helpers/rendering.rb
+++ b/lib/app/helpers/rendering.rb
@@ -48,6 +48,16 @@ module Integrity
             :config   => current_project.config_for(name) })
         }
       end
+
+      def json(resource)
+        headers "Content-Type" => "application/json;charset=utf-8"
+        resource.to_json
+      end
+
+      def json_error(code, message)
+        status code
+        json({ "error" => { "code" => code, "message" => message } })
+      end
     end
   end
 end

--- a/lib/app/helpers/urls.rb
+++ b/lib/app/helpers/urls.rb
@@ -35,6 +35,10 @@ module Integrity
         project_path(project).to_s.concat('.png')
       end
 
+      def project_json_url(project)
+        project_path(project).to_s.concat('.json')
+      end
+
       def root_url
         @root_url ||= Addressable::URI.parse(url_for("/", :full))
       end
@@ -66,7 +70,7 @@ module Integrity
       def build_path(build, *path)
         project_path(build.project, "builds", build.id, *path)
       end
-      
+
       def artifact_path(build, artifact, *path)
         build_path(build, 'artifacts', CGI.escape(CGI.escape(artifact)))
       end

--- a/lib/app/views/project.haml
+++ b/lib/app/views/project.haml
@@ -2,6 +2,8 @@
   %a{ :href => project_path(@project, :edit) } Edit
   = " / "
   %a{ :href => project_status_image_url(@project) } Status Image
+  = " / "
+  %a{ :href => project_json_url(@project) } JSON
   - if @project.github?
     = " / "
     %a{ :href => github_project_url(@project) }= github_project_link(@project)

--- a/lib/integrity/project.rb
+++ b/lib/integrity/project.rb
@@ -32,7 +32,7 @@ module Integrity
     def get_artifacts
       artifacts.split(";")
     end
-    
+
     def artifacts_empty?
       artifacts.nil? || artifacts.empty?
     end
@@ -96,9 +96,18 @@ module Integrity
     def human_status
       ! blank? && last_build.human_status
     end
-    
+
     def human_duration
       ! blank? && last_build.human_duration
+    end
+
+    def to_json
+      {
+        "project" => {
+          "name" => name,
+          "status" => status
+        }
+      }.to_json
     end
 
     private

--- a/test/acceptance/status_test.rb
+++ b/test/acceptance/status_test.rb
@@ -1,0 +1,55 @@
+require "helper/acceptance"
+
+class StatusTest < Test::Unit::AcceptanceTestCase
+  story <<-EOS
+    As a user,
+    I want to check my project status
+  EOS
+
+  scenario "Get public project info in JSON format" do
+    successful_project = Project.gen :successful
+
+    get "/#{successful_project.permalink}.json"
+
+    assert_equal "application/json;charset=utf-8", response_content_type
+
+    assert_equal parse_response_as_json, {
+      "project" => {
+        "name" => successful_project.name,
+        "status" => "success"
+      }
+    }
+  end
+
+  scenario "Get private project info in JSON format" do
+    private_project = Project.gen :public => false
+
+    get "/#{private_project.permalink}.json"
+
+    assert_equal "application/json;charset=utf-8", response_content_type
+
+    assert_equal 401, response_code
+
+    json = {
+      "error" => {
+        "code" => 401,
+        "message" => "Authorization Required"
+      }
+    }
+
+    assert_equal json, parse_response_as_json
+
+    login_as "admin", "test"
+
+    get "/#{private_project.permalink}.json"
+
+    json = {
+      "project" => {
+        "name" => private_project.name,
+        "status" => "blank"
+      }
+    }
+
+    assert_equal json, parse_response_as_json
+  end
+end

--- a/test/helper/acceptance.rb
+++ b/test/helper/acceptance.rb
@@ -31,6 +31,14 @@ module AcceptanceHelper
     rack_test_session.header("Authorization", nil)
   end
 
+  def parse_response_as_json
+    JSON.parse response.body
+  end
+
+  def response_content_type
+    response.headers["Content-Type"]
+  end
+
   # thanks http://github.com/ichverstehe
   def mock_socket
     socket, server = MockSocket.new, MockSocket.new

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -88,4 +88,18 @@ class ProjectTest < IntegrityTest
     assert ! Project.gen(:my_test_project).github?
   end
 
+  test "to_json" do
+    project = Project.gen :successful
+
+    parsed_json = JSON.parse project.to_json
+    json = {
+      "project" => {
+        "name" => project.name,
+        "status" => "success"
+      }
+    }
+
+    assert_equal json, parsed_json
+  end
+
 end


### PR DESCRIPTION
Hi guys,

Regarding the issue #150 I just did some work on the .json endpoints. Could you tell what you think? 

Do you think the /, /:project/builds, /:project/builds/:builds need JSON endpoints too? I'm not sure how it could be useful. 

PS: I've being using the /:project.json with my Arduino, and it's working well so far :smile: 
