### PR TITLE
Fix build under ruby 2.0.0

### DIFF
--- a/lib/app/helpers/resources.rb
+++ b/lib/app/helpers/resources.rb
@@ -7,7 +7,7 @@ module Integrity
       end
 
       def current_build
-        @build ||= current_project.builds.get(params[:build]) or
+        @build ||= current_project.builds.get(params[:build].to_i) or
           raise Sinatra::NotFound
       end
 


### PR DESCRIPTION
Strangely in 2.0.0 `project.builds.get("1")` do not work anymore but `projects.builds.get(1)` still do.
So as a workaround I just cast the parameter from sinatra, but it may be a DataMapper issue.

Fixes #238
