### PR TITLE
Fix Integrity on ruby 2.0.

### DIFF
--- a/lib/integrity.rb
+++ b/lib/integrity.rb
@@ -30,6 +30,23 @@ require "addressable/uri"
 require "chronic_duration"
 require "bcat/ansi"
 
+# Workaround for https://github.com/datamapper/dm-core/issues/242
+if RUBY_VERSION[0] == ?2
+  class DataMapper::Property
+    alias :typecast_without_integrity_fix :typecast
+    def typecast(value)
+      rv = typecast_without_integrity_fix(value)
+      if value.nil? || !rv.nil?
+        rv
+      elsif respond_to?(:typecast_to_primitive, true)
+        typecast_to_primitive(value)
+      else
+        rv
+      end
+    end
+  end
+end
+
 require "app/app"
 
 require "integrity/configuration"


### PR DESCRIPTION
Add a workaround patch for https://github.com/datamapper/dm-core/issues/242.

Alternative fix to #240 for #238.

@byroot what do you think of this?
