### PR TITLE
Use release-1.2 branch of databapper to fix ruby 2.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,12 @@ gem 'data_mapper',       '~> 1.2'
 gem 'dm-sqlite-adapter'
 gem 'do_sqlite3'
 
+# Workaround until https://github.com/datamapper/dm-core/issues/242
+# is fixed in a released version of datamapper.
+gem 'dm-core',
+  :git => 'git://github.com/datamapper/dm-core',
+  :branch => 'release-1.2'
+
 gem 'haml'
 gem 'sass'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: git://github.com/datamapper/dm-core
+  revision: 9224447f73ff861a0870135564d1aa5df37b6eaa
+  branch: release-1.2
+  specs:
+    dm-core (1.2.1)
+      addressable (~> 2.3.3)
+
+GIT
   remote: git://github.com/p/dm-sweatshop-without-parsetree
   revision: 623ed21c1e75072401a85530c09cc2c8ff029ac2
   branch: integrity
@@ -21,7 +29,7 @@ GEM
     activesupport (3.2.13)
       i18n (= 0.6.1)
       multi_json (~> 1.0)
-    addressable (2.2.8)
+    addressable (2.3.3)
     ansi (1.4.3)
     arel (3.0.2)
     aws-ses (0.4.4)
@@ -62,8 +70,6 @@ GEM
       dm-core (~> 1.2.0)
     dm-constraints (1.2.0)
       dm-core (~> 1.2.0)
-    dm-core (1.2.0)
-      addressable (~> 2.2.6)
     dm-do-adapter (1.2.0)
       data_objects (~> 0.10.6)
       dm-core (~> 1.2.0)
@@ -167,6 +173,7 @@ DEPENDENCIES
   data_mapper (~> 1.2)
   delayed_job
   delayed_job_active_record
+  dm-core!
   dm-sqlite-adapter
   dm-sweatshop!
   do_sqlite3


### PR DESCRIPTION
Alternative fix to #240 and #246 for #238.

@byroot ping.

When https://github.com/datamapper/dm-core/issues/242 fix makes it into a datamapper release, this PR should be reverted.
