### PR TITLE
Preserve project command formating in textarea

### DIFF
--- a/lib/app/views/new.haml
+++ b/lib/app/views/new.haml
@@ -21,8 +21,7 @@
   %p.normal{ :class => error_class(@project, :command) }
     %label{ :for => "project_build_script" }
       &== Build script #{errors_on(@project, :command)}
-    %textarea#project_build_script{ :name => "project_data[command]", :cols => 40, :rows => 2 }
-      &== #{@project.command.to_s}
+    %textarea#project_build_script{ :name => "project_data[command]", :cols => 40, :rows => 2 }~ @project.command.to_s
   
   %p.normal{ :class => error_class(@project, :artifacts) }
     %label{ :for => "project_artifacts" }<

--- a/test/acceptance/edit_test.rb
+++ b/test/acceptance/edit_test.rb
@@ -66,4 +66,18 @@ class EditTest < Test::Unit::AcceptanceTestCase
     branch = field.element['value']
     assert_equal 'testbranch&', branch
   end
+
+  scenario "Preserve multiline command formating" do
+    content = "build\nscript"
+    Project.gen(:integrity, :public => true, :command => content)
+    login_as "admin", "test"
+
+    visit "/integrity"
+    click_link "Edit"
+
+    field = field_by_xpath('//textarea[@name="project_data[command]"]')
+    command = field.element.text
+    assert_equal content, command
+  end
+
 end


### PR DESCRIPTION
A tiny bug that piss me off every time I edit a project.
See http://haml.info/docs/yardoc/file.FAQ.html#q-preserve

Regards.
