### PR TITLE
Default HELO hostname in email notifier.

### DIFF
--- a/lib/integrity/notifier/email.haml
+++ b/lib/integrity/notifier/email.haml
@@ -37,7 +37,7 @@
   - dropdown("notifiers[Email][auth]", "email_notifier_auth", %w[plain login cram_md5], config["auth"])
 
 %p.normal
-  %label{ :for => "email_notifier_domain" } Domain
+  %label{ :for => "email_notifier_domain" } HELO hostname
   %input.text#email_notifier_domain{ :name => "notifiers[Email][domain]", :value => config["domain"], :type => "text" }
 
 

--- a/lib/integrity/notifier/email.rb
+++ b/lib/integrity/notifier/email.rb
@@ -59,10 +59,19 @@ module Integrity
             :user_name            => user,
             :password             => pass,
             :authentication       => @config["auth"],
-            :domain               => @config["domain"]
+            :domain               => helo_hostname,
           }
 
           Pony.options = { :via => :smtp, :via_options => options }
+        end
+        
+        def helo_hostname
+          domain = @config["domain"]
+          if domain && !domain.empty?
+            domain
+          else
+            Socket.gethostname
+          end
         end
 
         def configure_sendmail


### PR DESCRIPTION
See https://github.com/mikel/mail/issues/640 for further details.

Requiring the hostname to be specified when talking to local MTA
is silly.

Lastly, the correct term is HELO hostname, not domain.
